### PR TITLE
fix: log the client IP if X-Real-IP header is being used

### DIFF
--- a/src/main/java/org/alexdev/duckhttpd/server/connection/WebConnection.java
+++ b/src/main/java/org/alexdev/duckhttpd/server/connection/WebConnection.java
@@ -73,7 +73,9 @@ public class WebConnection {
         String ipAddress = ((InetSocketAddress)this.channel.remoteAddress()).getAddress().toString().substring(1);
 
         if (this.httpRequest != null) {
-            if (this.httpRequest.headers().contains("X-Forwarded-For")) {
+            if (this.httpRequest.headers().contains("X-Real-IP")){
+                ipAddress = this.httpRequest.headers().get("X-Real-IP");
+            } else if (this.httpRequest.headers().contains("X-Forwarded-For")) {
                 ipAddress = this.httpRequest.headers().get("X-Forwarded-For");
             } else if (this.httpRequest.headers().contains("HTTP_CF_CONNECTING_IP")) {
                 ipAddress = this.httpRequest.headers().get("HTTP_CF_CONNECTING_IP");


### PR DESCRIPTION
Currently the library attempts to log IP addresses using the `X-Forwarded-For` header but this results in the proxy IP being logged as well. The downside of this is if you are using something like nginx to reverse proxy all traffic to the local services then you end up in a situation where every user registering/accessing the site logs the proxy address and that results in the `max.connections.per.ip` setting being applied globally i.e. if `max.connections.per.ip` is set to 2 then only 2 users can register in the hotel.

This was necessary for my particular setup, not sure if it's a desirable change in the upstream repo but figured I'd open a PR just in case you have an interest. Feel free to close if not, ty!